### PR TITLE
[hot fix] Fix import errors in RPC related modules

### DIFF
--- a/src/agentscope/agents/rpc_agent.py
+++ b/src/agentscope/agents/rpc_agent.py
@@ -32,15 +32,15 @@ except ImportError:
 from agentscope._init import _INIT_SETTINGS
 from agentscope._init import init
 from agentscope.agents.agent import AgentBase
-from agentscope.rpc.rpc_agent_pb2 import RpcMsg  # pylint: disable=E0611
 from agentscope.message import MessageBase
 from agentscope.message import Msg
 from agentscope.message import PlaceholderMessage
 from agentscope.message import deserialize
 from agentscope.message import serialize
 from agentscope.utils.logging_utils import logger
-from agentscope.rpc.rpc_agent_client import RpcAgentClient
-from agentscope.rpc.rpc_agent_pb2_grpc import (
+from agentscope.rpc import (
+    RpcAgentClient,
+    RpcMsg,
     RpcAgentServicer,
     add_RpcAgentServicer_to_server,
 )

--- a/src/agentscope/message.py
+++ b/src/agentscope/message.py
@@ -7,7 +7,7 @@ import json
 
 from loguru import logger
 
-from .rpc.rpc_agent_client import RpcAgentClient
+from .rpc import RpcAgentClient
 from .utils.tools import _get_timestamp
 
 

--- a/src/agentscope/rpc/__init__.py
+++ b/src/agentscope/rpc/__init__.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+"""Import all rpc related modules in the package."""
+from typing import Any
+from .rpc_agent_client import RpcAgentClient
+
+try:
+    from .rpc_agent_pb2 import RpcMsg  # pylint: disable=E0611
+except ModuleNotFoundError:
+    RpcMsg = Any
+try:
+    from .rpc_agent_pb2_grpc import RpcAgentServicer
+    from .rpc_agent_pb2_grpc import RpcAgentStub
+    from .rpc_agent_pb2_grpc import add_RpcAgentServicer_to_server
+except ImportError:
+    RpcAgentServicer = object
+    RpcAgentStub = Any
+    add_RpcAgentServicer_to_server = Any
+
+
+__all__ = [
+    "RpcAgentClient",
+    "RpcMsg",
+    "RpcAgentServicer",
+    "RpcAgentStub",
+    "add_RpcAgentServicer_to_server",
+]

--- a/src/agentscope/rpc/rpc_agent_client.py
+++ b/src/agentscope/rpc/rpc_agent_client.py
@@ -1,13 +1,19 @@
 # -*- coding: utf-8 -*-
 """ Client of rpc agent server """
 
+from typing import Any
+
 try:
     import grpc
 except ImportError:
     grpc = None
 
-from agentscope.rpc.rpc_agent_pb2 import RpcMsg  # pylint: disable=E0611
-from agentscope.rpc.rpc_agent_pb2_grpc import RpcAgentStub
+try:
+    from agentscope.rpc.rpc_agent_pb2 import RpcMsg  # pylint: disable=E0611
+    from agentscope.rpc.rpc_agent_pb2_grpc import RpcAgentStub
+except ModuleNotFoundError:
+    RpcMsg = Any
+    RpcAgentStub = Any
 
 
 class RpcAgentClient:


### PR DESCRIPTION
---
name: Fix import errors in RPC related modules
---
## Description

Fixed the bug that RPC related modules throw `ModuleNotFoundError` under default installation conditions


## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has passed all tests
- [x]  Docstrings have been added/updated in Google Style
- [x]  Documentation has been updated
- [x]  Code is ready for review